### PR TITLE
[CHANGE] adding vagrant to provision demos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode
 *.swp
+vagrant/.vagrant/

--- a/README.md
+++ b/README.md
@@ -5,10 +5,14 @@ More detailed descriptions and high-level architecture descriptions are availabl
 
 ## Running examples using vagrant and virtualbox
 
-We currently provide the following examples.
-More examples to come soon!
+This fork introduces vagrant to help setting up a ready to use environment with examples and has been developed at 
+<a href="https://www.areti.it"> 
+    <img src="https://www.areti.it/content/dam/acea-areti/icone-loghi/pittogramma_areti_colore.svg" alt="AReti" style="width:50px;"/> areti 
+</a> to further ease the execution.
+
+Each example runs in a vm (8gb ram, 2cpu).
+We currently provide the following examples:
 
 - [PMU Data Visualization](pmu-data-visualization) execute:  `cd vagrant && vagrant up pmudatavisualization`
 - [Pyvolt DPsim Demo](pyvolt-dpsim-demo) execute:  `cd vagrant && vagrant up pyvoltdpsim`
 - [Simulation Demo](simulation-demo) execute: `cd vagrant && vagrant up simulation`
-

--- a/README.md
+++ b/README.md
@@ -3,11 +3,12 @@
 This repository contains deployment instructions and configuration files for different example deployments of the SOGNO platform.
 More detailed descriptions and high-level architecture descriptions are available on our official [documentation](https://sogno-platform.github.io/docs/) pages.
 
-## Examples
+## Running examples using vagrant and virtualbox
 
 We currently provide the following examples.
 More examples to come soon!
 
-- [PMU Data Visualization](pmu-data-visualization)
-- [Pyvolt DPsim Demo](pyvolt-dpsim-demo)
-- [Simulation Demo](simulation-demo)
+- [PMU Data Visualization](pmu-data-visualization) execute:  `cd vagrant && vagrant up pmudatavisualization`
+- [Pyvolt DPsim Demo](pyvolt-dpsim-demo) execute:  `cd vagrant && vagrant up pyvoltdpsim`
+- [Simulation Demo](simulation-demo) execute: `cd vagrant && vagrant up simulation`
+

--- a/pyvolt-dpsim-demo/visualization/dashboard-configmap.yaml
+++ b/pyvolt-dpsim-demo/visualization/dashboard-configmap.yaml
@@ -11,253 +11,866 @@ data:
           "list": [
             {
               "builtIn": 1,
-              "datasource": "-- Grafana --",
+              "datasource": {
+                "type": "datasource",
+                "uid": "grafana"
+              },
               "enable": true,
               "hide": true,
               "iconColor": "rgba(0, 211, 255, 1)",
               "name": "Annotations & Alerts",
+              "target": {
+                "limit": 100,
+                "matchAny": false,
+                "tags": [],
+                "type": "dashboard"
+              },
               "type": "dashboard"
             }
           ]
         },
         "editable": true,
-        "gnetId": null,
+        "fiscalYearStartMonth": 0,
         "graphTooltip": 0,
+        "id": 3,
         "links": [],
+        "liveNow": false,
         "panels": [
           {
-            "aliasColors": {},
-            "bars": false,
-            "dashLength": 10,
-            "dashes": false,
-            "datasource": "InfluxDB",
-            "fieldConfig": {
-              "defaults": {
-                "custom": {}
-              },
-              "overrides": []
-            },
-            "fill": 1,
-            "fillGradient": 0,
+            "collapsed": true,
             "gridPos": {
-              "h": 9,
+              "h": 1,
               "w": 24,
               "x": 0,
-              "y": 0
+              "y": 8
             },
-            "hiddenSeries": false,
-            "id": 2,
-            "legend": {
-              "avg": false,
-              "current": false,
-              "max": false,
-              "min": false,
-              "show": true,
-              "total": false,
-              "values": false
-            },
-            "lines": true,
-            "linewidth": 1,
-            "nullPointMode": "null",
-            "options": {
-              "alertThreshold": true
-            },
-            "percentage": false,
-            "pluginVersion": "7.4.3",
-            "pointradius": 2,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "spaceLength": 10,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
+            "id": 9,
+            "panels": [
               {
-                "alias": "Original N2",
-                "groupBy": [
+                "datasource": {
+                  "type": "influxdb",
+                  "uid": "P951FEA4DE68E13C5"
+                },
+                "fieldConfig": {
+                  "defaults": {
+                    "color": {
+                      "mode": "palette-classic"
+                    },
+                    "custom": {
+                      "axisLabel": "",
+                      "axisPlacement": "auto",
+                      "barAlignment": 0,
+                      "drawStyle": "line",
+                      "fillOpacity": 10,
+                      "gradientMode": "none",
+                      "hideFrom": {
+                        "legend": false,
+                        "tooltip": false,
+                        "viz": false
+                      },
+                      "lineInterpolation": "linear",
+                      "lineWidth": 1,
+                      "pointSize": 5,
+                      "scaleDistribution": {
+                        "type": "linear"
+                      },
+                      "showPoints": "never",
+                      "spanNulls": false,
+                      "stacking": {
+                        "group": "A",
+                        "mode": "none"
+                      },
+                      "thresholdsStyle": {
+                        "mode": "off"
+                      }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green"
+                        },
+                        {
+                          "color": "red",
+                          "value": 80
+                        }
+                      ]
+                    }
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 9,
+                  "w": 24,
+                  "x": 0,
+                  "y": 1
+                },
+                "id": 4,
+                "options": {
+                  "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom"
+                  },
+                  "tooltip": {
+                    "mode": "multi",
+                    "sort": "none"
+                  }
+                },
+                "pluginVersion": "9.0.5",
+                "targets": [
                   {
-                    "params": [
-                      "$__interval"
+                    "alias": "Original N1",
+                    "datasource": {
+                      "type": "influxdb",
+                      "uid": "P951FEA4DE68E13C5"
+                    },
+                    "groupBy": [
+                      {
+                        "params": [
+                          "$__interval"
+                        ],
+                        "type": "time"
+                      },
+                      {
+                        "params": [
+                          "linear"
+                        ],
+                        "type": "fill"
+                      }
                     ],
-                    "type": "time"
+                    "measurement": "mqtt_consumer",
+                    "orderByTime": "ASC",
+                    "policy": "default",
+                    "queryType": "randomWalk",
+                    "refId": "A",
+                    "resultFormat": "time_series",
+                    "select": [
+                      [
+                        {
+                          "params": [
+                            "data_2"
+                          ],
+                          "type": "field"
+                        },
+                        {
+                          "params": [],
+                          "type": "last"
+                        },
+                        {
+                          "params": [
+                            " / 1000"
+                          ],
+                          "type": "math"
+                        }
+                      ]
+                    ],
+                    "tags": [
+                      {
+                        "key": "topic",
+                        "operator": "=",
+                        "value": "/dpsim-powerflow"
+                      }
+                    ]
                   },
                   {
-                    "params": [
-                      "linear"
+                    "alias": "Estimate N1",
+                    "datasource": {
+                      "type": "influxdb",
+                      "uid": "P951FEA4DE68E13C5"
+                    },
+                    "groupBy": [
+                      {
+                        "params": [
+                          "$__interval"
+                        ],
+                        "type": "time"
+                      },
+                      {
+                        "params": [
+                          "linear"
+                        ],
+                        "type": "fill"
+                      }
                     ],
-                    "type": "fill"
+                    "hide": false,
+                    "measurement": "mqtt_consumer",
+                    "orderByTime": "ASC",
+                    "policy": "default",
+                    "queryType": "randomWalk",
+                    "refId": "B",
+                    "resultFormat": "time_series",
+                    "select": [
+                      [
+                        {
+                          "params": [
+                            "data_32"
+                          ],
+                          "type": "field"
+                        },
+                        {
+                          "params": [],
+                          "type": "last"
+                        }
+                      ]
+                    ],
+                    "tags": [
+                      {
+                        "key": "topic",
+                        "operator": "=",
+                        "value": "/se"
+                      }
+                    ]
                   }
                 ],
-                "measurement": "mqtt_consumer",
-                "orderByTime": "ASC",
-                "policy": "default",
-                "queryType": "randomWalk",
-                "refId": "A",
-                "resultFormat": "time_series",
-                "select": [
-                  [
-                    {
-                      "params": [
-                        "data_4"
-                      ],
-                      "type": "field"
-                    },
-                    {
-                      "params": [],
-                      "type": "last"
-                    },
-                    {
-                      "params": [
-                        " / 1000"
-                      ],
-                      "type": "math"
-                    }
-                  ]
-                ],
-                "tags": [
-                  {
-                    "key": "topic",
-                    "operator": "=",
-                    "value": "/dpsim-powerflow"
-                  }
-                ]
+                "title": "Node 1",
+                "type": "timeseries"
               },
               {
-                "alias": "Estimate N2",
-                "groupBy": [
+                "datasource": {
+                  "type": "influxdb",
+                  "uid": "P951FEA4DE68E13C5"
+                },
+                "fieldConfig": {
+                  "defaults": {
+                    "color": {
+                      "mode": "palette-classic"
+                    },
+                    "custom": {
+                      "axisLabel": "",
+                      "axisPlacement": "auto",
+                      "barAlignment": 0,
+                      "drawStyle": "line",
+                      "fillOpacity": 10,
+                      "gradientMode": "none",
+                      "hideFrom": {
+                        "legend": false,
+                        "tooltip": false,
+                        "viz": false
+                      },
+                      "lineInterpolation": "linear",
+                      "lineWidth": 1,
+                      "pointSize": 5,
+                      "scaleDistribution": {
+                        "type": "linear"
+                      },
+                      "showPoints": "never",
+                      "spanNulls": false,
+                      "stacking": {
+                        "group": "A",
+                        "mode": "none"
+                      },
+                      "thresholdsStyle": {
+                        "mode": "off"
+                      }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green"
+                        },
+                        {
+                          "color": "red",
+                          "value": 80
+                        }
+                      ]
+                    }
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 9,
+                  "w": 24,
+                  "x": 0,
+                  "y": 10
+                },
+                "id": 7,
+                "options": {
+                  "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom"
+                  },
+                  "tooltip": {
+                    "mode": "multi",
+                    "sort": "none"
+                  }
+                },
+                "pluginVersion": "9.0.5",
+                "targets": [
                   {
-                    "params": [
-                      "$__interval"
+                    "alias": "Original theta N2",
+                    "datasource": {
+                      "type": "influxdb",
+                      "uid": "P951FEA4DE68E13C5"
+                    },
+                    "groupBy": [
+                      {
+                        "params": [
+                          "$__interval"
+                        ],
+                        "type": "time"
+                      },
+                      {
+                        "params": [
+                          "linear"
+                        ],
+                        "type": "fill"
+                      }
                     ],
-                    "type": "time"
+                    "measurement": "mqtt_consumer",
+                    "orderByTime": "ASC",
+                    "policy": "default",
+                    "queryType": "randomWalk",
+                    "refId": "A",
+                    "resultFormat": "time_series",
+                    "select": [
+                      [
+                        {
+                          "params": [
+                            "data_3"
+                          ],
+                          "type": "field"
+                        },
+                        {
+                          "params": [],
+                          "type": "last"
+                        }
+                      ]
+                    ],
+                    "tags": [
+                      {
+                        "key": "topic",
+                        "operator": "=",
+                        "value": "/dpsim-powerflow"
+                      }
+                    ]
                   },
                   {
-                    "params": [
-                      "linear"
-                    ],
-                    "type": "fill"
-                  }
-                ],
-                "hide": false,
-                "measurement": "mqtt_consumer",
-                "orderByTime": "ASC",
-                "policy": "default",
-                "queryType": "randomWalk",
-                "refId": "B",
-                "resultFormat": "time_series",
-                "select": [
-                  [
-                    {
-                      "params": [
-                        "data_34"
-                      ],
-                      "type": "field"
+                    "alias": "Exstimated theta N2",
+                    "datasource": {
+                      "type": "influxdb",
+                      "uid": "P951FEA4DE68E13C5"
                     },
-                    {
-                      "params": [],
-                      "type": "last"
-                    }
-                  ]
-                ],
-                "tags": [
-                  {
-                    "key": "topic",
-                    "operator": "=",
-                    "value": "/se"
+                    "groupBy": [
+                      {
+                        "params": [
+                          "$__interval"
+                        ],
+                        "type": "time"
+                      },
+                      {
+                        "params": [
+                          "linear"
+                        ],
+                        "type": "fill"
+                      }
+                    ],
+                    "hide": false,
+                    "measurement": "mqtt_consumer",
+                    "orderByTime": "ASC",
+                    "policy": "default",
+                    "queryType": "randomWalk",
+                    "refId": "B",
+                    "resultFormat": "time_series",
+                    "select": [
+                      [
+                        {
+                          "params": [
+                            "data_33"
+                          ],
+                          "type": "field"
+                        },
+                        {
+                          "params": [],
+                          "type": "last"
+                        }
+                      ]
+                    ],
+                    "tags": [
+                      {
+                        "key": "topic",
+                        "operator": "=",
+                        "value": "/se"
+                      }
+                    ]
                   }
-                ]
+                ],
+                "title": "Node 1 - Imag",
+                "type": "timeseries"
               }
             ],
-            "thresholds": [],
-            "timeFrom": null,
-            "timeRegions": [],
-            "timeShift": null,
-            "title": "Node 2",
-            "tooltip": {
-              "shared": true,
-              "sort": 0,
-              "value_type": "individual"
-            },
-            "type": "graph",
-            "xaxis": {
-              "buckets": null,
-              "mode": "time",
-              "name": null,
-              "show": true,
-              "values": []
-            },
-            "yaxes": [
-              {
-                "format": "short",
-                "label": null,
-                "logBase": 1,
-                "max": null,
-                "min": null,
-                "show": true
-              },
-              {
-                "format": "short",
-                "label": null,
-                "logBase": 1,
-                "max": null,
-                "min": null,
-                "show": true
-              }
-            ],
-            "yaxis": {
-              "align": false,
-              "alignLevel": null
-            }
+            "title": "Node 1",
+            "type": "row"
           },
           {
-            "aliasColors": {},
-            "bars": false,
-            "dashLength": 10,
-            "dashes": false,
-            "datasource": "InfluxDB",
-            "fieldConfig": {
-              "defaults": {
-                "custom": {}
-              },
-              "overrides": []
-            },
-            "fill": 1,
-            "fillGradient": 0,
+            "collapsed": true,
             "gridPos": {
-              "h": 9,
+              "h": 1,
               "w": 24,
               "x": 0,
               "y": 9
             },
-            "hiddenSeries": false,
-            "id": 3,
-            "legend": {
-              "avg": false,
-              "current": false,
-              "max": false,
-              "min": false,
-              "show": true,
-              "total": false,
-              "values": false
+            "id": 6,
+            "panels": [
+              {
+                "datasource": {
+                  "type": "influxdb",
+                  "uid": "P951FEA4DE68E13C5"
+                },
+                "fieldConfig": {
+                  "defaults": {
+                    "color": {
+                      "mode": "palette-classic"
+                    },
+                    "custom": {
+                      "axisLabel": "",
+                      "axisPlacement": "auto",
+                      "barAlignment": 0,
+                      "drawStyle": "line",
+                      "fillOpacity": 10,
+                      "gradientMode": "none",
+                      "hideFrom": {
+                        "legend": false,
+                        "tooltip": false,
+                        "viz": false
+                      },
+                      "lineInterpolation": "linear",
+                      "lineWidth": 1,
+                      "pointSize": 5,
+                      "scaleDistribution": {
+                        "type": "linear"
+                      },
+                      "showPoints": "never",
+                      "spanNulls": false,
+                      "stacking": {
+                        "group": "A",
+                        "mode": "none"
+                      },
+                      "thresholdsStyle": {
+                        "mode": "off"
+                      }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green"
+                        },
+                        {
+                          "color": "red",
+                          "value": 80
+                        }
+                      ]
+                    }
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 9,
+                  "w": 24,
+                  "x": 0,
+                  "y": 2
+                },
+                "id": 2,
+                "options": {
+                  "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom"
+                  },
+                  "tooltip": {
+                    "mode": "multi",
+                    "sort": "none"
+                  }
+                },
+                "pluginVersion": "9.0.5",
+                "targets": [
+                  {
+                    "alias": "Original N2",
+                    "datasource": {
+                      "type": "influxdb",
+                      "uid": "P951FEA4DE68E13C5"
+                    },
+                    "groupBy": [
+                      {
+                        "params": [
+                          "$__interval"
+                        ],
+                        "type": "time"
+                      },
+                      {
+                        "params": [
+                          "linear"
+                        ],
+                        "type": "fill"
+                      }
+                    ],
+                    "measurement": "mqtt_consumer",
+                    "orderByTime": "ASC",
+                    "policy": "default",
+                    "queryType": "randomWalk",
+                    "refId": "A",
+                    "resultFormat": "time_series",
+                    "select": [
+                      [
+                        {
+                          "params": [
+                            "data_4"
+                          ],
+                          "type": "field"
+                        },
+                        {
+                          "params": [],
+                          "type": "last"
+                        },
+                        {
+                          "params": [
+                            " / 1000"
+                          ],
+                          "type": "math"
+                        }
+                      ]
+                    ],
+                    "tags": [
+                      {
+                        "key": "topic",
+                        "operator": "=",
+                        "value": "/dpsim-powerflow"
+                      }
+                    ]
+                  },
+                  {
+                    "alias": "Estimate N2",
+                    "datasource": {
+                      "type": "influxdb",
+                      "uid": "P951FEA4DE68E13C5"
+                    },
+                    "groupBy": [
+                      {
+                        "params": [
+                          "$__interval"
+                        ],
+                        "type": "time"
+                      },
+                      {
+                        "params": [
+                          "linear"
+                        ],
+                        "type": "fill"
+                      }
+                    ],
+                    "hide": false,
+                    "measurement": "mqtt_consumer",
+                    "orderByTime": "ASC",
+                    "policy": "default",
+                    "queryType": "randomWalk",
+                    "refId": "B",
+                    "resultFormat": "time_series",
+                    "select": [
+                      [
+                        {
+                          "params": [
+                            "data_34"
+                          ],
+                          "type": "field"
+                        },
+                        {
+                          "params": [],
+                          "type": "last"
+                        }
+                      ]
+                    ],
+                    "tags": [
+                      {
+                        "key": "topic",
+                        "operator": "=",
+                        "value": "/se"
+                      }
+                    ]
+                  }
+                ],
+                "title": "Node 2",
+                "type": "timeseries"
+              },
+              {
+                "datasource": {
+                  "type": "influxdb",
+                  "uid": "P951FEA4DE68E13C5"
+                },
+                "fieldConfig": {
+                  "defaults": {
+                    "color": {
+                      "mode": "palette-classic"
+                    },
+                    "custom": {
+                      "axisLabel": "",
+                      "axisPlacement": "auto",
+                      "barAlignment": 0,
+                      "drawStyle": "line",
+                      "fillOpacity": 10,
+                      "gradientMode": "none",
+                      "hideFrom": {
+                        "legend": false,
+                        "tooltip": false,
+                        "viz": false
+                      },
+                      "lineInterpolation": "linear",
+                      "lineWidth": 1,
+                      "pointSize": 5,
+                      "scaleDistribution": {
+                        "type": "linear"
+                      },
+                      "showPoints": "never",
+                      "spanNulls": false,
+                      "stacking": {
+                        "group": "A",
+                        "mode": "none"
+                      },
+                      "thresholdsStyle": {
+                        "mode": "off"
+                      }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green"
+                        },
+                        {
+                          "color": "red",
+                          "value": 80
+                        }
+                      ]
+                    }
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 9,
+                  "w": 24,
+                  "x": 0,
+                  "y": 11
+                },
+                "id": 10,
+                "options": {
+                  "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom"
+                  },
+                  "tooltip": {
+                    "mode": "multi",
+                    "sort": "none"
+                  }
+                },
+                "pluginVersion": "9.0.5",
+                "targets": [
+                  {
+                    "alias": "Original theta N2",
+                    "datasource": {
+                      "type": "influxdb",
+                      "uid": "P951FEA4DE68E13C5"
+                    },
+                    "groupBy": [
+                      {
+                        "params": [
+                          "$__interval"
+                        ],
+                        "type": "time"
+                      },
+                      {
+                        "params": [
+                          "linear"
+                        ],
+                        "type": "fill"
+                      }
+                    ],
+                    "measurement": "mqtt_consumer",
+                    "orderByTime": "ASC",
+                    "policy": "default",
+                    "queryType": "randomWalk",
+                    "refId": "A",
+                    "resultFormat": "time_series",
+                    "select": [
+                      [
+                        {
+                          "params": [
+                            "data_5"
+                          ],
+                          "type": "field"
+                        },
+                        {
+                          "params": [],
+                          "type": "last"
+                        }
+                      ]
+                    ],
+                    "tags": [
+                      {
+                        "key": "topic",
+                        "operator": "=",
+                        "value": "/dpsim-powerflow"
+                      }
+                    ]
+                  },
+                  {
+                    "alias": "Exstimated theta N2",
+                    "datasource": {
+                      "type": "influxdb",
+                      "uid": "P951FEA4DE68E13C5"
+                    },
+                    "groupBy": [
+                      {
+                        "params": [
+                          "$__interval"
+                        ],
+                        "type": "time"
+                      },
+                      {
+                        "params": [
+                          "linear"
+                        ],
+                        "type": "fill"
+                      }
+                    ],
+                    "hide": false,
+                    "measurement": "mqtt_consumer",
+                    "orderByTime": "ASC",
+                    "policy": "default",
+                    "queryType": "randomWalk",
+                    "refId": "B",
+                    "resultFormat": "time_series",
+                    "select": [
+                      [
+                        {
+                          "params": [
+                            "data_35"
+                          ],
+                          "type": "field"
+                        },
+                        {
+                          "params": [],
+                          "type": "last"
+                        }
+                      ]
+                    ],
+                    "tags": [
+                      {
+                        "key": "topic",
+                        "operator": "=",
+                        "value": "/se"
+                      }
+                    ]
+                  }
+                ],
+                "title": "Node 2 - imag",
+                "type": "timeseries"
+              }
+            ],
+            "title": "Node 2",
+            "type": "row"
+          },
+          {
+            "collapsed": false,
+            "gridPos": {
+              "h": 1,
+              "w": 24,
+              "x": 0,
+              "y": 10
             },
-            "lines": true,
-            "linewidth": 1,
-            "nullPointMode": "null",
+            "id": 17,
+            "panels": [],
+            "title": "Node 3",
+            "type": "row"
+          },
+          {
+            "datasource": {
+              "type": "influxdb",
+              "uid": "P951FEA4DE68E13C5"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                },
+                "unit": "kvolt"
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 9,
+              "w": 24,
+              "x": 0,
+              "y": 11
+            },
+            "id": 14,
             "options": {
-              "alertThreshold": true
+              "legend": {
+                "calcs": [],
+                "displayMode": "list",
+                "placement": "bottom"
+              },
+              "tooltip": {
+                "mode": "multi",
+                "sort": "none"
+              }
             },
-            "percentage": false,
-            "pluginVersion": "7.4.3",
-            "pointradius": 2,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "spaceLength": 10,
-            "stack": false,
-            "steppedLine": false,
+            "pluginVersion": "9.0.5",
             "targets": [
               {
-                "alias": "Original N11",
+                "alias": "Original N3",
+                "datasource": {
+                  "type": "influxdb",
+                  "uid": "P951FEA4DE68E13C5"
+                },
                 "groupBy": [
                   {
                     "params": [
@@ -282,7 +895,7 @@ data:
                   [
                     {
                       "params": [
-                        "data_22"
+                        "data_6"
                       ],
                       "type": "field"
                     },
@@ -307,7 +920,11 @@ data:
                 ]
               },
               {
-                "alias": "Estimate N11",
+                "alias": "Estimate N3",
+                "datasource": {
+                  "type": "influxdb",
+                  "uid": "P951FEA4DE68E13C5"
+                },
                 "groupBy": [
                   {
                     "params": [
@@ -333,7 +950,7 @@ data:
                   [
                     {
                       "params": [
-                        "data_44"
+                        "data_36"
                       ],
                       "type": "field"
                     },
@@ -352,62 +969,2039 @@ data:
                 ]
               }
             ],
-            "thresholds": [],
-            "timeFrom": null,
-            "timeRegions": [],
-            "timeShift": null,
-            "title": "Node 11",
-            "tooltip": {
-              "shared": true,
-              "sort": 0,
-              "value_type": "individual"
+            "title": "Node 3",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "influxdb",
+              "uid": "P951FEA4DE68E13C5"
             },
-            "type": "graph",
-            "xaxis": {
-              "buckets": null,
-              "mode": "time",
-              "name": null,
-              "show": true,
-              "values": []
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                }
+              },
+              "overrides": []
             },
-            "yaxes": [
+            "gridPos": {
+              "h": 9,
+              "w": 24,
+              "x": 0,
+              "y": 20
+            },
+            "id": 15,
+            "options": {
+              "legend": {
+                "calcs": [],
+                "displayMode": "list",
+                "placement": "bottom"
+              },
+              "tooltip": {
+                "mode": "multi",
+                "sort": "none"
+              }
+            },
+            "pluginVersion": "9.0.5",
+            "targets": [
               {
-                "format": "short",
-                "label": null,
-                "logBase": 1,
-                "max": null,
-                "min": null,
-                "show": true
+                "alias": "Original theta N3",
+                "datasource": {
+                  "type": "influxdb",
+                  "uid": "P951FEA4DE68E13C5"
+                },
+                "groupBy": [
+                  {
+                    "params": [
+                      "$__interval"
+                    ],
+                    "type": "time"
+                  },
+                  {
+                    "params": [
+                      "linear"
+                    ],
+                    "type": "fill"
+                  }
+                ],
+                "measurement": "mqtt_consumer",
+                "orderByTime": "ASC",
+                "policy": "default",
+                "queryType": "randomWalk",
+                "refId": "A",
+                "resultFormat": "time_series",
+                "select": [
+                  [
+                    {
+                      "params": [
+                        "data_7"
+                      ],
+                      "type": "field"
+                    },
+                    {
+                      "params": [],
+                      "type": "last"
+                    }
+                  ]
+                ],
+                "tags": [
+                  {
+                    "key": "topic",
+                    "operator": "=",
+                    "value": "/dpsim-powerflow"
+                  }
+                ]
               },
               {
-                "format": "short",
-                "label": null,
-                "logBase": 1,
-                "max": null,
-                "min": null,
-                "show": true
+                "alias": "Exstimated theta N3",
+                "datasource": {
+                  "type": "influxdb",
+                  "uid": "P951FEA4DE68E13C5"
+                },
+                "groupBy": [
+                  {
+                    "params": [
+                      "$__interval"
+                    ],
+                    "type": "time"
+                  },
+                  {
+                    "params": [
+                      "linear"
+                    ],
+                    "type": "fill"
+                  }
+                ],
+                "hide": false,
+                "measurement": "mqtt_consumer",
+                "orderByTime": "ASC",
+                "policy": "default",
+                "queryType": "randomWalk",
+                "refId": "B",
+                "resultFormat": "time_series",
+                "select": [
+                  [
+                    {
+                      "params": [
+                        "data_37"
+                      ],
+                      "type": "field"
+                    },
+                    {
+                      "params": [],
+                      "type": "last"
+                    }
+                  ]
+                ],
+                "tags": [
+                  {
+                    "key": "topic",
+                    "operator": "=",
+                    "value": "/se"
+                  }
+                ]
               }
             ],
-            "yaxis": {
-              "align": false,
-              "alignLevel": null
-            }
+            "title": "Node 3 - imag",
+            "type": "timeseries"
+          },
+          {
+            "collapsed": false,
+            "gridPos": {
+              "h": 1,
+              "w": 24,
+              "x": 0,
+              "y": 29
+            },
+            "id": 19,
+            "panels": [],
+            "title": "Node 4",
+            "type": "row"
+          },
+          {
+            "datasource": {
+              "type": "influxdb",
+              "uid": "P951FEA4DE68E13C5"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                },
+                "unit": "kvolt"
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 9,
+              "w": 24,
+              "x": 0,
+              "y": 30
+            },
+            "id": 20,
+            "options": {
+              "legend": {
+                "calcs": [],
+                "displayMode": "list",
+                "placement": "bottom"
+              },
+              "tooltip": {
+                "mode": "multi",
+                "sort": "none"
+              }
+            },
+            "pluginVersion": "9.0.5",
+            "targets": [
+              {
+                "alias": "Original N4",
+                "datasource": {
+                  "type": "influxdb",
+                  "uid": "P951FEA4DE68E13C5"
+                },
+                "groupBy": [
+                  {
+                    "params": [
+                      "$__interval"
+                    ],
+                    "type": "time"
+                  },
+                  {
+                    "params": [
+                      "linear"
+                    ],
+                    "type": "fill"
+                  }
+                ],
+                "measurement": "mqtt_consumer",
+                "orderByTime": "ASC",
+                "policy": "default",
+                "queryType": "randomWalk",
+                "refId": "A",
+                "resultFormat": "time_series",
+                "select": [
+                  [
+                    {
+                      "params": [
+                        "data_8"
+                      ],
+                      "type": "field"
+                    },
+                    {
+                      "params": [],
+                      "type": "last"
+                    },
+                    {
+                      "params": [
+                        " / 1000"
+                      ],
+                      "type": "math"
+                    }
+                  ]
+                ],
+                "tags": [
+                  {
+                    "key": "topic",
+                    "operator": "=",
+                    "value": "/dpsim-powerflow"
+                  }
+                ]
+              },
+              {
+                "alias": "Estimate N4",
+                "datasource": {
+                  "type": "influxdb",
+                  "uid": "P951FEA4DE68E13C5"
+                },
+                "groupBy": [
+                  {
+                    "params": [
+                      "$__interval"
+                    ],
+                    "type": "time"
+                  },
+                  {
+                    "params": [
+                      "linear"
+                    ],
+                    "type": "fill"
+                  }
+                ],
+                "hide": false,
+                "measurement": "mqtt_consumer",
+                "orderByTime": "ASC",
+                "policy": "default",
+                "queryType": "randomWalk",
+                "refId": "B",
+                "resultFormat": "time_series",
+                "select": [
+                  [
+                    {
+                      "params": [
+                        "data_38"
+                      ],
+                      "type": "field"
+                    },
+                    {
+                      "params": [],
+                      "type": "last"
+                    }
+                  ]
+                ],
+                "tags": [
+                  {
+                    "key": "topic",
+                    "operator": "=",
+                    "value": "/se"
+                  }
+                ]
+              }
+            ],
+            "title": "Node 4",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "influxdb",
+              "uid": "P951FEA4DE68E13C5"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 9,
+              "w": 24,
+              "x": 0,
+              "y": 39
+            },
+            "id": 21,
+            "options": {
+              "legend": {
+                "calcs": [],
+                "displayMode": "list",
+                "placement": "bottom"
+              },
+              "tooltip": {
+                "mode": "multi",
+                "sort": "none"
+              }
+            },
+            "pluginVersion": "9.0.5",
+            "targets": [
+              {
+                "alias": "Original theta N4",
+                "datasource": {
+                  "type": "influxdb",
+                  "uid": "P951FEA4DE68E13C5"
+                },
+                "groupBy": [
+                  {
+                    "params": [
+                      "$__interval"
+                    ],
+                    "type": "time"
+                  },
+                  {
+                    "params": [
+                      "linear"
+                    ],
+                    "type": "fill"
+                  }
+                ],
+                "measurement": "mqtt_consumer",
+                "orderByTime": "ASC",
+                "policy": "default",
+                "queryType": "randomWalk",
+                "refId": "A",
+                "resultFormat": "time_series",
+                "select": [
+                  [
+                    {
+                      "params": [
+                        "data_9"
+                      ],
+                      "type": "field"
+                    },
+                    {
+                      "params": [],
+                      "type": "last"
+                    }
+                  ]
+                ],
+                "tags": [
+                  {
+                    "key": "topic",
+                    "operator": "=",
+                    "value": "/dpsim-powerflow"
+                  }
+                ]
+              },
+              {
+                "alias": "Exstimated theta N4",
+                "datasource": {
+                  "type": "influxdb",
+                  "uid": "P951FEA4DE68E13C5"
+                },
+                "groupBy": [
+                  {
+                    "params": [
+                      "$__interval"
+                    ],
+                    "type": "time"
+                  },
+                  {
+                    "params": [
+                      "linear"
+                    ],
+                    "type": "fill"
+                  }
+                ],
+                "hide": false,
+                "measurement": "mqtt_consumer",
+                "orderByTime": "ASC",
+                "policy": "default",
+                "queryType": "randomWalk",
+                "refId": "B",
+                "resultFormat": "time_series",
+                "select": [
+                  [
+                    {
+                      "params": [
+                        "data_39"
+                      ],
+                      "type": "field"
+                    },
+                    {
+                      "params": [],
+                      "type": "last"
+                    }
+                  ]
+                ],
+                "tags": [
+                  {
+                    "key": "topic",
+                    "operator": "=",
+                    "value": "/se"
+                  }
+                ]
+              }
+            ],
+            "title": "Node 4 - imag",
+            "type": "timeseries"
+          },
+          {
+            "collapsed": false,
+            "gridPos": {
+              "h": 1,
+              "w": 24,
+              "x": 0,
+              "y": 48
+            },
+            "id": 19,
+            "panels": [],
+            "title": "Node 5",
+            "type": "row"
+          },
+          {
+            "datasource": {
+              "type": "influxdb",
+              "uid": "P951FEA4DE68E13C5"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                },
+                "unit": "kvolt"
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 9,
+              "w": 24,
+              "x": 0,
+              "y": 49
+            },
+            "id": 20,
+            "options": {
+              "legend": {
+                "calcs": [],
+                "displayMode": "list",
+                "placement": "bottom"
+              },
+              "tooltip": {
+                "mode": "multi",
+                "sort": "none"
+              }
+            },
+            "pluginVersion": "9.0.5",
+            "targets": [
+              {
+                "alias": "Original N5",
+                "datasource": {
+                  "type": "influxdb",
+                  "uid": "P951FEA4DE68E13C5"
+                },
+                "groupBy": [
+                  {
+                    "params": [
+                      "$__interval"
+                    ],
+                    "type": "time"
+                  },
+                  {
+                    "params": [
+                      "linear"
+                    ],
+                    "type": "fill"
+                  }
+                ],
+                "measurement": "mqtt_consumer",
+                "orderByTime": "ASC",
+                "policy": "default",
+                "queryType": "randomWalk",
+                "refId": "A",
+                "resultFormat": "time_series",
+                "select": [
+                  [
+                    {
+                      "params": [
+                        "data_10"
+                      ],
+                      "type": "field"
+                    },
+                    {
+                      "params": [],
+                      "type": "last"
+                    },
+                    {
+                      "params": [
+                        " / 1000"
+                      ],
+                      "type": "math"
+                    }
+                  ]
+                ],
+                "tags": [
+                  {
+                    "key": "topic",
+                    "operator": "=",
+                    "value": "/dpsim-powerflow"
+                  }
+                ]
+              },
+              {
+                "alias": "Estimate N5",
+                "datasource": {
+                  "type": "influxdb",
+                  "uid": "P951FEA4DE68E13C5"
+                },
+                "groupBy": [
+                  {
+                    "params": [
+                      "$__interval"
+                    ],
+                    "type": "time"
+                  },
+                  {
+                    "params": [
+                      "linear"
+                    ],
+                    "type": "fill"
+                  }
+                ],
+                "hide": false,
+                "measurement": "mqtt_consumer",
+                "orderByTime": "ASC",
+                "policy": "default",
+                "queryType": "randomWalk",
+                "refId": "B",
+                "resultFormat": "time_series",
+                "select": [
+                  [
+                    {
+                      "params": [
+                        "data_40"
+                      ],
+                      "type": "field"
+                    },
+                    {
+                      "params": [],
+                      "type": "last"
+                    }
+                  ]
+                ],
+                "tags": [
+                  {
+                    "key": "topic",
+                    "operator": "=",
+                    "value": "/se"
+                  }
+                ]
+              }
+            ],
+            "title": "Node 5",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "influxdb",
+              "uid": "P951FEA4DE68E13C5"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 9,
+              "w": 24,
+              "x": 0,
+              "y": 58
+            },
+            "id": 21,
+            "options": {
+              "legend": {
+                "calcs": [],
+                "displayMode": "list",
+                "placement": "bottom"
+              },
+              "tooltip": {
+                "mode": "multi",
+                "sort": "none"
+              }
+            },
+            "pluginVersion": "9.0.5",
+            "targets": [
+              {
+                "alias": "Original theta N5",
+                "datasource": {
+                  "type": "influxdb",
+                  "uid": "P951FEA4DE68E13C5"
+                },
+                "groupBy": [
+                  {
+                    "params": [
+                      "$__interval"
+                    ],
+                    "type": "time"
+                  },
+                  {
+                    "params": [
+                      "linear"
+                    ],
+                    "type": "fill"
+                  }
+                ],
+                "measurement": "mqtt_consumer",
+                "orderByTime": "ASC",
+                "policy": "default",
+                "queryType": "randomWalk",
+                "refId": "A",
+                "resultFormat": "time_series",
+                "select": [
+                  [
+                    {
+                      "params": [
+                        "data_11"
+                      ],
+                      "type": "field"
+                    },
+                    {
+                      "params": [],
+                      "type": "last"
+                    }
+                  ]
+                ],
+                "tags": [
+                  {
+                    "key": "topic",
+                    "operator": "=",
+                    "value": "/dpsim-powerflow"
+                  }
+                ]
+              },
+              {
+                "alias": "Estimated theta N5",
+                "datasource": {
+                  "type": "influxdb",
+                  "uid": "P951FEA4DE68E13C5"
+                },
+                "groupBy": [
+                  {
+                    "params": [
+                      "$__interval"
+                    ],
+                    "type": "time"
+                  },
+                  {
+                    "params": [
+                      "linear"
+                    ],
+                    "type": "fill"
+                  }
+                ],
+                "hide": false,
+                "measurement": "mqtt_consumer",
+                "orderByTime": "ASC",
+                "policy": "default",
+                "queryType": "randomWalk",
+                "refId": "B",
+                "resultFormat": "time_series",
+                "select": [
+                  [
+                    {
+                      "params": [
+                        "data_41"
+                      ],
+                      "type": "field"
+                    },
+                    {
+                      "params": [],
+                      "type": "last"
+                    }
+                  ]
+                ],
+                "tags": [
+                  {
+                    "key": "topic",
+                    "operator": "=",
+                    "value": "/se"
+                  }
+                ]
+              }
+            ],
+            "title": "Node 5 - imag",
+            "type": "timeseries"
+          },
+          {
+            "collapsed": false,
+            "gridPos": {
+              "h": 1,
+              "w": 24,
+              "x": 0,
+              "y": 67
+            },
+            "id": 19,
+            "panels": [],
+            "title": "Node 6",
+            "type": "row"
+          },
+          {
+            "datasource": {
+              "type": "influxdb",
+              "uid": "P951FEA4DE68E13C5"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                },
+                "unit": "kvolt"
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 9,
+              "w": 24,
+              "x": 0,
+              "y": 68
+            },
+            "id": 20,
+            "options": {
+              "legend": {
+                "calcs": [],
+                "displayMode": "list",
+                "placement": "bottom"
+              },
+              "tooltip": {
+                "mode": "multi",
+                "sort": "none"
+              }
+            },
+            "pluginVersion": "9.0.5",
+            "targets": [
+              {
+                "alias": "Original N6",
+                "datasource": {
+                  "type": "influxdb",
+                  "uid": "P951FEA4DE68E13C5"
+                },
+                "groupBy": [
+                  {
+                    "params": [
+                      "$__interval"
+                    ],
+                    "type": "time"
+                  },
+                  {
+                    "params": [
+                      "linear"
+                    ],
+                    "type": "fill"
+                  }
+                ],
+                "measurement": "mqtt_consumer",
+                "orderByTime": "ASC",
+                "policy": "default",
+                "queryType": "randomWalk",
+                "refId": "A",
+                "resultFormat": "time_series",
+                "select": [
+                  [
+                    {
+                      "params": [
+                        "data_12"
+                      ],
+                      "type": "field"
+                    },
+                    {
+                      "params": [],
+                      "type": "last"
+                    },
+                    {
+                      "params": [
+                        " / 1000"
+                      ],
+                      "type": "math"
+                    }
+                  ]
+                ],
+                "tags": [
+                  {
+                    "key": "topic",
+                    "operator": "=",
+                    "value": "/dpsim-powerflow"
+                  }
+                ]
+              },
+              {
+                "alias": "Estimate N6",
+                "datasource": {
+                  "type": "influxdb",
+                  "uid": "P951FEA4DE68E13C5"
+                },
+                "groupBy": [
+                  {
+                    "params": [
+                      "$__interval"
+                    ],
+                    "type": "time"
+                  },
+                  {
+                    "params": [
+                      "linear"
+                    ],
+                    "type": "fill"
+                  }
+                ],
+                "hide": false,
+                "measurement": "mqtt_consumer",
+                "orderByTime": "ASC",
+                "policy": "default",
+                "queryType": "randomWalk",
+                "refId": "B",
+                "resultFormat": "time_series",
+                "select": [
+                  [
+                    {
+                      "params": [
+                        "data_42"
+                      ],
+                      "type": "field"
+                    },
+                    {
+                      "params": [],
+                      "type": "last"
+                    }
+                  ]
+                ],
+                "tags": [
+                  {
+                    "key": "topic",
+                    "operator": "=",
+                    "value": "/se"
+                  }
+                ]
+              }
+            ],
+            "title": "Node 6",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "influxdb",
+              "uid": "P951FEA4DE68E13C5"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 9,
+              "w": 24,
+              "x": 0,
+              "y": 77
+            },
+            "id": 21,
+            "options": {
+              "legend": {
+                "calcs": [],
+                "displayMode": "list",
+                "placement": "bottom"
+              },
+              "tooltip": {
+                "mode": "multi",
+                "sort": "none"
+              }
+            },
+            "pluginVersion": "9.0.5",
+            "targets": [
+              {
+                "alias": "Original theta N6",
+                "datasource": {
+                  "type": "influxdb",
+                  "uid": "P951FEA4DE68E13C5"
+                },
+                "groupBy": [
+                  {
+                    "params": [
+                      "$__interval"
+                    ],
+                    "type": "time"
+                  },
+                  {
+                    "params": [
+                      "linear"
+                    ],
+                    "type": "fill"
+                  }
+                ],
+                "measurement": "mqtt_consumer",
+                "orderByTime": "ASC",
+                "policy": "default",
+                "queryType": "randomWalk",
+                "refId": "A",
+                "resultFormat": "time_series",
+                "select": [
+                  [
+                    {
+                      "params": [
+                        "data_13"
+                      ],
+                      "type": "field"
+                    },
+                    {
+                      "params": [],
+                      "type": "last"
+                    }
+                  ]
+                ],
+                "tags": [
+                  {
+                    "key": "topic",
+                    "operator": "=",
+                    "value": "/dpsim-powerflow"
+                  }
+                ]
+              },
+              {
+                "alias": "Estimated theta N6",
+                "datasource": {
+                  "type": "influxdb",
+                  "uid": "P951FEA4DE68E13C5"
+                },
+                "groupBy": [
+                  {
+                    "params": [
+                      "$__interval"
+                    ],
+                    "type": "time"
+                  },
+                  {
+                    "params": [
+                      "linear"
+                    ],
+                    "type": "fill"
+                  }
+                ],
+                "hide": false,
+                "measurement": "mqtt_consumer",
+                "orderByTime": "ASC",
+                "policy": "default",
+                "queryType": "randomWalk",
+                "refId": "B",
+                "resultFormat": "time_series",
+                "select": [
+                  [
+                    {
+                      "params": [
+                        "data_43"
+                      ],
+                      "type": "field"
+                    },
+                    {
+                      "params": [],
+                      "type": "last"
+                    }
+                  ]
+                ],
+                "tags": [
+                  {
+                    "key": "topic",
+                    "operator": "=",
+                    "value": "/se"
+                  }
+                ]
+              }
+            ],
+            "title": "Node 6 - imag",
+            "type": "timeseries"
+          },
+          {
+            "collapsed": true,
+            "gridPos": {
+              "h": 1,
+              "w": 24,
+              "x": 0,
+              "y": 86
+            },
+            "id": 12,
+            "panels": [
+              {
+                "aliasColors": {},
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": {
+                  "type": "influxdb",
+                  "uid": "P951FEA4DE68E13C5"
+                },
+                "fill": 1,
+                "fillGradient": 0,
+                "gridPos": {
+                  "h": 9,
+                  "w": 24,
+                  "x": 0,
+                  "y": 5
+                },
+                "hiddenSeries": false,
+                "id": 3,
+                "legend": {
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "show": true,
+                  "total": false,
+                  "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "nullPointMode": "null",
+                "options": {
+                  "alertThreshold": true
+                },
+                "percentage": false,
+                "pluginVersion": "9.0.5",
+                "pointradius": 2,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [
+                  {
+                    "alias": "Original N11",
+                    "datasource": {
+                      "type": "influxdb",
+                      "uid": "P951FEA4DE68E13C5"
+                    },
+                    "groupBy": [
+                      {
+                        "params": [
+                          "$__interval"
+                        ],
+                        "type": "time"
+                      },
+                      {
+                        "params": [
+                          "linear"
+                        ],
+                        "type": "fill"
+                      }
+                    ],
+                    "measurement": "mqtt_consumer",
+                    "orderByTime": "ASC",
+                    "policy": "default",
+                    "queryType": "randomWalk",
+                    "refId": "A",
+                    "resultFormat": "time_series",
+                    "select": [
+                      [
+                        {
+                          "params": [
+                            "data_22"
+                          ],
+                          "type": "field"
+                        },
+                        {
+                          "params": [],
+                          "type": "last"
+                        },
+                        {
+                          "params": [
+                            " / 1000"
+                          ],
+                          "type": "math"
+                        }
+                      ]
+                    ],
+                    "tags": [
+                      {
+                        "key": "topic",
+                        "operator": "=",
+                        "value": "/dpsim-powerflow"
+                      }
+                    ]
+                  },
+                  {
+                    "alias": "Estimate N11",
+                    "datasource": {
+                      "type": "influxdb",
+                      "uid": "P951FEA4DE68E13C5"
+                    },
+                    "groupBy": [
+                      {
+                        "params": [
+                          "$__interval"
+                        ],
+                        "type": "time"
+                      },
+                      {
+                        "params": [
+                          "linear"
+                        ],
+                        "type": "fill"
+                      }
+                    ],
+                    "hide": false,
+                    "measurement": "mqtt_consumer",
+                    "orderByTime": "ASC",
+                    "policy": "default",
+                    "queryType": "randomWalk",
+                    "refId": "B",
+                    "resultFormat": "time_series",
+                    "select": [
+                      [
+                        {
+                          "params": [
+                            "data_52"
+                          ],
+                          "type": "field"
+                        },
+                        {
+                          "params": [],
+                          "type": "last"
+                        }
+                      ]
+                    ],
+                    "tags": [
+                      {
+                        "key": "topic",
+                        "operator": "=",
+                        "value": "/se"
+                      }
+                    ]
+                  }
+                ],
+                "thresholds": [],
+                "timeRegions": [],
+                "title": "Node 11",
+                "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                  "mode": "time",
+                  "show": true,
+                  "values": []
+                },
+                "yaxes": [
+                  {
+                    "format": "short",
+                    "logBase": 1,
+                    "show": true
+                  },
+                  {
+                    "format": "short",
+                    "logBase": 1,
+                    "show": true
+                  }
+                ],
+                "yaxis": {
+                  "align": false
+                }
+              },
+              {
+                "aliasColors": {},
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": {
+                  "type": "influxdb",
+                  "uid": "P951FEA4DE68E13C5"
+                },
+                "fill": 1,
+                "fillGradient": 0,
+                "gridPos": {
+                  "h": 9,
+                  "w": 24,
+                  "x": 0,
+                  "y": 14
+                },
+                "hiddenSeries": false,
+                "id": 13,
+                "legend": {
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "show": true,
+                  "total": false,
+                  "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "nullPointMode": "null",
+                "options": {
+                  "alertThreshold": true
+                },
+                "percentage": false,
+                "pluginVersion": "9.0.5",
+                "pointradius": 2,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [
+                  {
+                    "alias": "Original N11",
+                    "datasource": {
+                      "type": "influxdb",
+                      "uid": "P951FEA4DE68E13C5"
+                    },
+                    "groupBy": [
+                      {
+                        "params": [
+                          "$__interval"
+                        ],
+                        "type": "time"
+                      },
+                      {
+                        "params": [
+                          "linear"
+                        ],
+                        "type": "fill"
+                      }
+                    ],
+                    "measurement": "mqtt_consumer",
+                    "orderByTime": "ASC",
+                    "policy": "default",
+                    "queryType": "randomWalk",
+                    "refId": "A",
+                    "resultFormat": "time_series",
+                    "select": [
+                      [
+                        {
+                          "params": [
+                            "data_23"
+                          ],
+                          "type": "field"
+                        },
+                        {
+                          "params": [],
+                          "type": "last"
+                        }
+                      ]
+                    ],
+                    "tags": [
+                      {
+                        "key": "topic",
+                        "operator": "=",
+                        "value": "/dpsim-powerflow"
+                      }
+                    ]
+                  },
+                  {
+                    "alias": "Estimate N11",
+                    "datasource": {
+                      "type": "influxdb",
+                      "uid": "P951FEA4DE68E13C5"
+                    },
+                    "groupBy": [
+                      {
+                        "params": [
+                          "$__interval"
+                        ],
+                        "type": "time"
+                      },
+                      {
+                        "params": [
+                          "linear"
+                        ],
+                        "type": "fill"
+                      }
+                    ],
+                    "hide": false,
+                    "measurement": "mqtt_consumer",
+                    "orderByTime": "ASC",
+                    "policy": "default",
+                    "queryType": "randomWalk",
+                    "refId": "B",
+                    "resultFormat": "time_series",
+                    "select": [
+                      [
+                        {
+                          "params": [
+                            "data_53"
+                          ],
+                          "type": "field"
+                        },
+                        {
+                          "params": [],
+                          "type": "last"
+                        }
+                      ]
+                    ],
+                    "tags": [
+                      {
+                        "key": "topic",
+                        "operator": "=",
+                        "value": "/se"
+                      }
+                    ]
+                  }
+                ],
+                "thresholds": [],
+                "timeRegions": [],
+                "title": "Node 12",
+                "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                  "mode": "time",
+                  "show": true,
+                  "values": []
+                },
+                "yaxes": [
+                  {
+                    "format": "short",
+                    "logBase": 1,
+                    "show": true
+                  },
+                  {
+                    "format": "short",
+                    "logBase": 1,
+                    "show": true
+                  }
+                ],
+                "yaxis": {
+                  "align": false
+                }
+              }
+            ],
+            "title": "Node 11",
+            "type": "row"
+          },
+          {
+            "collapsed": true,
+            "gridPos": {
+              "h": 1,
+              "w": 24,
+              "x": 0,
+              "y": 87
+            },
+            "id": 12,
+            "panels": [
+              {
+                "aliasColors": {},
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": {
+                  "type": "influxdb",
+                  "uid": "P951FEA4DE68E13C5"
+                },
+                "fill": 1,
+                "fillGradient": 0,
+                "gridPos": {
+                  "h": 9,
+                  "w": 24,
+                  "x": 0,
+                  "y": 5
+                },
+                "hiddenSeries": false,
+                "id": 3,
+                "legend": {
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "show": true,
+                  "total": false,
+                  "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "nullPointMode": "null",
+                "options": {
+                  "alertThreshold": true
+                },
+                "percentage": false,
+                "pluginVersion": "9.0.5",
+                "pointradius": 2,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [
+                  {
+                    "alias": "Original N12",
+                    "datasource": {
+                      "type": "influxdb",
+                      "uid": "P951FEA4DE68E13C5"
+                    },
+                    "groupBy": [
+                      {
+                        "params": [
+                          "$__interval"
+                        ],
+                        "type": "time"
+                      },
+                      {
+                        "params": [
+                          "linear"
+                        ],
+                        "type": "fill"
+                      }
+                    ],
+                    "measurement": "mqtt_consumer",
+                    "orderByTime": "ASC",
+                    "policy": "default",
+                    "queryType": "randomWalk",
+                    "refId": "A",
+                    "resultFormat": "time_series",
+                    "select": [
+                      [
+                        {
+                          "params": [
+                            "data_24"
+                          ],
+                          "type": "field"
+                        },
+                        {
+                          "params": [],
+                          "type": "last"
+                        },
+                        {
+                          "params": [
+                            " / 1000"
+                          ],
+                          "type": "math"
+                        }
+                      ]
+                    ],
+                    "tags": [
+                      {
+                        "key": "topic",
+                        "operator": "=",
+                        "value": "/dpsim-powerflow"
+                      }
+                    ]
+                  },
+                  {
+                    "alias": "Estimate N12",
+                    "datasource": {
+                      "type": "influxdb",
+                      "uid": "P951FEA4DE68E13C5"
+                    },
+                    "groupBy": [
+                      {
+                        "params": [
+                          "$__interval"
+                        ],
+                        "type": "time"
+                      },
+                      {
+                        "params": [
+                          "linear"
+                        ],
+                        "type": "fill"
+                      }
+                    ],
+                    "hide": false,
+                    "measurement": "mqtt_consumer",
+                    "orderByTime": "ASC",
+                    "policy": "default",
+                    "queryType": "randomWalk",
+                    "refId": "B",
+                    "resultFormat": "time_series",
+                    "select": [
+                      [
+                        {
+                          "params": [
+                            "data_54"
+                          ],
+                          "type": "field"
+                        },
+                        {
+                          "params": [],
+                          "type": "last"
+                        }
+                      ]
+                    ],
+                    "tags": [
+                      {
+                        "key": "topic",
+                        "operator": "=",
+                        "value": "/se"
+                      }
+                    ]
+                  }
+                ],
+                "thresholds": [],
+                "timeRegions": [],
+                "title": "Node 12",
+                "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                  "mode": "time",
+                  "show": true,
+                  "values": []
+                },
+                "yaxes": [
+                  {
+                    "format": "short",
+                    "logBase": 1,
+                    "show": true
+                  },
+                  {
+                    "format": "short",
+                    "logBase": 1,
+                    "show": true
+                  }
+                ],
+                "yaxis": {
+                  "align": false
+                }
+              },
+              {
+                "aliasColors": {},
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": {
+                  "type": "influxdb",
+                  "uid": "P951FEA4DE68E13C5"
+                },
+                "fill": 1,
+                "fillGradient": 0,
+                "gridPos": {
+                  "h": 9,
+                  "w": 24,
+                  "x": 0,
+                  "y": 14
+                },
+                "hiddenSeries": false,
+                "id": 13,
+                "legend": {
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "show": true,
+                  "total": false,
+                  "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "nullPointMode": "null",
+                "options": {
+                  "alertThreshold": true
+                },
+                "percentage": false,
+                "pluginVersion": "9.0.5",
+                "pointradius": 2,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [
+                  {
+                    "alias": "Original N12",
+                    "datasource": {
+                      "type": "influxdb",
+                      "uid": "P951FEA4DE68E13C5"
+                    },
+                    "groupBy": [
+                      {
+                        "params": [
+                          "$__interval"
+                        ],
+                        "type": "time"
+                      },
+                      {
+                        "params": [
+                          "linear"
+                        ],
+                        "type": "fill"
+                      }
+                    ],
+                    "measurement": "mqtt_consumer",
+                    "orderByTime": "ASC",
+                    "policy": "default",
+                    "queryType": "randomWalk",
+                    "refId": "A",
+                    "resultFormat": "time_series",
+                    "select": [
+                      [
+                        {
+                          "params": [
+                            "data_25"
+                          ],
+                          "type": "field"
+                        },
+                        {
+                          "params": [],
+                          "type": "last"
+                        }
+                      ]
+                    ],
+                    "tags": [
+                      {
+                        "key": "topic",
+                        "operator": "=",
+                        "value": "/dpsim-powerflow"
+                      }
+                    ]
+                  },
+                  {
+                    "alias": "Estimate N12",
+                    "datasource": {
+                      "type": "influxdb",
+                      "uid": "P951FEA4DE68E13C5"
+                    },
+                    "groupBy": [
+                      {
+                        "params": [
+                          "$__interval"
+                        ],
+                        "type": "time"
+                      },
+                      {
+                        "params": [
+                          "linear"
+                        ],
+                        "type": "fill"
+                      }
+                    ],
+                    "hide": false,
+                    "measurement": "mqtt_consumer",
+                    "orderByTime": "ASC",
+                    "policy": "default",
+                    "queryType": "randomWalk",
+                    "refId": "B",
+                    "resultFormat": "time_series",
+                    "select": [
+                      [
+                        {
+                          "params": [
+                            "data_55"
+                          ],
+                          "type": "field"
+                        },
+                        {
+                          "params": [],
+                          "type": "last"
+                        }
+                      ]
+                    ],
+                    "tags": [
+                      {
+                        "key": "topic",
+                        "operator": "=",
+                        "value": "/se"
+                      }
+                    ]
+                  }
+                ],
+                "thresholds": [],
+                "timeRegions": [],
+                "title": "Node 12",
+                "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                  "mode": "time",
+                  "show": true,
+                  "values": []
+                },
+                "yaxes": [
+                  {
+                    "format": "short",
+                    "logBase": 1,
+                    "show": true
+                  },
+                  {
+                    "format": "short",
+                    "logBase": 1,
+                    "show": true
+                  }
+                ],
+                "yaxis": {
+                  "align": false
+                }
+              }
+            ],
+            "title": "Node 12",
+            "type": "row"
           }
         ],
         "refresh": false,
-        "schemaVersion": 27,
+        "schemaVersion": 36,
         "style": "dark",
         "tags": [],
         "templating": {
           "list": []
         },
         "time": {
-          "from": "2021-03-25T11:42:34.842Z",
-          "to": "2021-03-25T11:45:15.486Z"
+          "from": "now-5m",
+          "to": "now"
         },
         "timepicker": {},
         "timezone": "",
-        "title": "Pyvolt-DPsim-Demo",
-        "uid": "eOcXX7wGk",
-        "version": 1
+        "title": "Pyvolt-DPsim-Demo-new Copy",
+        "uid": "qHCj-KiVk",
+        "version": 1,
+        "weekStart": ""
       }

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -6,6 +6,7 @@ Vagrant.configure("2") do |config|
   config.vm.network "forwarded_port", guest: 8080, host: 8080, protocol: "tcp"
   config.vm.network "forwarded_port", guest: 6443, host: 6443, protocol: "tcp" #k3s control panel
   config.vm.box = "ubuntu/jammy64"        ## official canonical image 22.04 lts
+
   #commmon provisioning for all demos
   config.vm.provision :shell, path: "vagrant-basic-bootstrap.sh"
   config.vm.provider "vmware_workstation" do |v, override|

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -8,6 +8,9 @@ Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/jammy64"        ## official canonical image 22.04 lts
   #commmon provisioning for all demos
   config.vm.provision :shell, path: "vagrant-basic-bootstrap.sh"
+  config.vm.provider "vmware_workstation" do |v, override|
+    override.vm.box = "generic/ubuntu1804"
+  end
   #pyvolt-dpsim-demo https://github.com/sogno-platform/example-deployments/tree/main/pyvolt-dpsim-demo 
   config.vm.define "pyvoltdpsim" do |pyvoltdpsim|
     pyvoltdpsim.vm.hostname = "pyvoltdpsim"

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -4,7 +4,7 @@ Vagrant.configure("2") do |config|
   config.vm.network "forwarded_port", guest: 31230, host: 31230, protocol: "tcp"
   config.vm.network "forwarded_port", guest: 31234, host: 31234, protocol: "tcp"
   config.vm.network "forwarded_port", guest: 8080, host: 8080, protocol: "tcp"
-  config.vm.network "forwarded_port", guest: 6443, host: 6443, protocol: "tcp" #k3s control plane
+  config.vm.network "forwarded_port", guest: 6443, host: 6443, protocol: "tcp" #k3s control panel
   config.vm.box = "ubuntu/jammy64"        ## official canonical image 22.04 lts
   #commmon provisioning for all demos
   config.vm.provision :shell, path: "vagrant-basic-bootstrap.sh"

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -1,0 +1,41 @@
+#WARNING: installation will fail in case of air-gapped or proxied systems.
+
+Vagrant.configure("2") do |config|
+  config.vm.network "forwarded_port", guest: 31230, host: 31230, protocol: "tcp"
+  config.vm.network "forwarded_port", guest: 31234, host: 31234, protocol: "tcp"
+  config.vm.network "forwarded_port", guest: 8080, host: 8080, protocol: "tcp"
+  config.vm.network "forwarded_port", guest: 6443, host: 6443, protocol: "tcp" #k3s control plane
+  config.vm.box = "ubuntu/jammy64"        ## official canonical image 22.04 lts
+  #commmon provisioning for all demos
+  config.vm.provision :shell, path: "vagrant-basic-bootstrap.sh"
+  #pyvolt-dpsim-demo https://github.com/sogno-platform/example-deployments/tree/main/pyvolt-dpsim-demo 
+  config.vm.define "pyvoltdpsim" do |pyvoltdpsim|
+    pyvoltdpsim.vm.hostname = "pyvoltdpsim"
+    pyvoltdpsim.vm.provision :shell, path: "./pyvoltdpsimdemo.sh"
+    pyvoltdpsim.vm.provider "virtualbox" do |v|
+        v.name = "pyvoltdpsim"
+        v.memory = 8192
+        v.cpus = 2
+      end
+  end
+  #simulation-demo https://github.com/sogno-platform/example-deployments/tree/main/simulation-demo
+  config.vm.define "simulation" do |simulation|
+    simulation.vm.hostname = "simulation"
+    simulation.vm.provision :shell, path: "./simulationdemo.sh"
+    simulation.vm.provider "virtualbox" do |v|
+        v.name = "simulation"
+        v.memory = 8192
+        v.cpus = 2
+      end
+  end
+  #pmu data visualization demo https://github.com/sogno-platform/example-deployments/tree/main/pmu-data-visualization
+  config.vm.define "pmudatavisualization" do |pmudatavisualization|
+    pmudatavisualization.vm.hostname = "pmudatavisualization"
+    pmudatavisualization.vm.provision :shell, path:  "./pmudatavisualizationdemo.sh"
+    pmudatavisualization.vm.provider "virtualbox" do |v|
+        v.name = "pmudatavisualization"
+        v.memory = 8192
+        v.cpus = 2
+      end
+  end 
+end

--- a/vagrant/pmudatavisualizationdemo.sh
+++ b/vagrant/pmudatavisualizationdemo.sh
@@ -1,28 +1,65 @@
 #!/usr/bin/env bash
 
+#cleanup in case of halted vm wich is reprovisioning
+k3s kubectl delete deployments --all
+k3s kubectl delete services --all
+k3s kubectl delete pods --all --grace-period=0 --force
+k3s kubectl delete daemonset --all
+
+# some necessary fixes
+cat > example-deployments/pmu-data-visualization/ts-adapter/telegraf.conf<< EOF
+[[outputs.influxdb]]
+  urls = ["http://influxdb:8086"]
+  database = "telegraf"
+  skip_database_creation = false
+  username = "telegraf"
+  password = "telegraf"
+  retention_policy = ""
+  write_consistency = "any"
+  timeout = "5s"
+
+[[inputs.mqtt_consumer]]
+  servers = ["tcp://rabbitmq:1883"]
+
+  ## Topics that will be subscribed to.
+  topics = [
+    "/pmu/dev",
+    "/pmu/field"
+  ]
+
+  ## Username and password to connect MQTT server.
+  username = "admin"
+  password = "admin"
+
+  data_format = "json_struct"
+  json_struct_name = "sogno-device"
+EOF
+
+
+cp -f example-deployments/pyvolt-dpsim-demo/visualization/grafana_values.yaml example-deployments/pmu-data-visualization/visualization/
+
 cd example-deployments/pmu-data-visualization
 
-sudo helm install -n sogno-datavis-demo --create-namespace -f databus/rabbitmq_values.yaml rabbitmq bitnami/rabbitmq
-sudo helm install influxdb influxdata/influxdb -n sogno-datavis-demo -f ts-database/influxdb-helm-values.yaml
-kubectl --namespace sogno-datavis-demo get pods
+# rabbitMQ
+sudo helm install rabbitmq bitnami/rabbitmq --kubeconfig /etc/rancher/k3s/k3s.yaml -f databus/rabbitmq_values.yaml 
+# Influx db
+sudo helm install influxdb influxdata/influxdb --kubeconfig /etc/rancher/k3s/k3s.yaml -f database/influxdb-helm-values.yaml
+# Grafana
+sudo helm install grafana grafana/grafana --kubeconfig /etc/rancher/k3s/k3s.yaml -f visualization/grafana_values.yaml
 
-#TODO:
-#Find the pod
-#
-#$ kubectl --namespace sogno-datavis-demo get pods
-#Login to the pod
-#
-#$ kubectl --namespace sogno-datavis-demo exec -i -t [pod name] /bin/sh
-#Run influxdb CLI
-#
-#$ influx
-#Create database and user telegraf and grant access
-#
-#> CREATE DATABASE telegraf
-#> SHOW Databases
-#> CREATE USER telegraf WITH PASSWORD 'telegraf'
-#> GRANT ALL ON "telegraf" TO "telegraf"
+#patched version of Telegraf as a database adapter, we deploy the adapter in conjunction with the created config map
+k3s kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml apply -k ts-adapter/
+k3s kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml apply -f ts-adapter/telegraf-deployment.yaml
 
+# wait until all the pods are running
+k3s kubectl wait --for=condition=Ready pods --all
+# start manually telegraf into the pod with the patched telegraf version 
+TELEGRAFPODNAME=$(k3s kubectl get pods | grep telegraf | awk '{print $1}')
+k3s kubectl wait --for=condition=Running pod $TELEGRAFPODNAME
+# relaunch it detached (started previously in the image rwthacs/telegraf-sogno )
+k3s kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml exec $TELEGRAFPODNAME -- bash -c './go/bin/telegraf'> /dev/null 2>&1 &
 
-sudo helm install grafana stable/grafana -f visualization/grafana_values.yaml
-kubectl get secret -n sogno-datavis-demo grafana -o jsonpath="{.data.admin-password}" | base64 --decode ; echo
+echo "Pods running:"
+k3s kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml get pods -o wide
+echo "Password for Web UI:"
+k3s kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml get secret grafana -o jsonpath="{.data.admin-password}" | base64 --decode ; echo

--- a/vagrant/pmudatavisualizationdemo.sh
+++ b/vagrant/pmudatavisualizationdemo.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+cd example-deployments/pmu-data-visualization
+
+sudo helm install -n sogno-datavis-demo --create-namespace -f databus/rabbitmq_values.yaml rabbitmq bitnami/rabbitmq
+sudo helm install influxdb influxdata/influxdb -n sogno-datavis-demo -f ts-database/influxdb-helm-values.yaml
+kubectl --namespace sogno-datavis-demo get pods
+
+#TODO:
+#Find the pod
+#
+#$ kubectl --namespace sogno-datavis-demo get pods
+#Login to the pod
+#
+#$ kubectl --namespace sogno-datavis-demo exec -i -t [pod name] /bin/sh
+#Run influxdb CLI
+#
+#$ influx
+#Create database and user telegraf and grant access
+#
+#> CREATE DATABASE telegraf
+#> SHOW Databases
+#> CREATE USER telegraf WITH PASSWORD 'telegraf'
+#> GRANT ALL ON "telegraf" TO "telegraf"
+
+
+sudo helm install grafana stable/grafana -f visualization/grafana_values.yaml
+kubectl get secret -n sogno-datavis-demo grafana -o jsonpath="{.data.admin-password}" | base64 --decode ; echo

--- a/vagrant/pyvoltdpsimdemo.sh
+++ b/vagrant/pyvoltdpsimdemo.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+#sogno-demo DATABUS: install rabbitmq via helm
+# The `rabbitmq_values.yaml` file contains SOGNO specific overwrites of the default rabbitMQ values.
+cat > /etc/rancher/k3s/rabbitmq_values.yaml<< EOF
+extraPlugins: rabbitmq_mqtt
+
+service:
+  extraPorts:
+    - name: mqtt
+      port: 1883
+      targetPort: 1883
+  nodePort: LoadBalancer
+
+auth:
+  username: admin
+  password: admin
+EOF
+
+RABBITMQISRUNNING=`k3s kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml get pod rabbitmq-0 --output="jsonpath={.status.containerStatuses[*].ready}" | cut -d' ' -f2`
+echo "Rabbitmq already running? $RABBITMQISRUNNING";
+if [ ! "$RABBITMQISRUNNING" = true ] ;
+then
+    echo "Installazione di rabbitmq"
+    sudo helm install -f /etc/rancher/k3s/rabbitmq_values.yaml --kubeconfig /etc/rancher/k3s/k3s.yaml rabbitmq bitnami/rabbitmq
+fi
+
+cd example-deployments/pyvolt-dpsim-demo
+# Influx db
+sudo helm install influxdb influxdata/influxdb --kubeconfig /etc/rancher/k3s/k3s.yaml -f database/influxdb-helm-values.yaml
+# DB adapter
+sudo helm install telegraf influxdata/telegraf --kubeconfig /etc/rancher/k3s/k3s.yaml -f ts-adapter/telegraf-values.yaml
+# Grafana http://localhost:31230  Username and password for Grafana are set to "demo".
+sudo helm install grafana grafana/grafana --kubeconfig /etc/rancher/k3s/k3s.yaml -f visualization/grafana_values.yaml
+kubectl apply -f visualization/dashboard-configmap.yaml --kubeconfig /etc/rancher/k3s/k3s.yaml
+# Pintura http://localhost:31234
+sudo helm install pintura sogno/pintura --kubeconfig /etc/rancher/k3s/k3s.yaml -f cim-editor/pintura_values.yaml
+# DPsim Simulation
+sudo helm install dpsim-demo sogno/dpsim-demo --kubeconfig /etc/rancher/k3s/k3s.yaml
+# State-Estimation
+sudo helm install pyvolt-demo sogno/pyvolt-service --kubeconfig /etc/rancher/k3s/k3s.yaml -f state-estimation/se_values.yaml
+echo "Pods running:"
+k3s kubectl get pods --all-namespaces -o wide

--- a/vagrant/pyvoltdpsimdemo.sh
+++ b/vagrant/pyvoltdpsimdemo.sh
@@ -1,5 +1,23 @@
 #!/usr/bin/env bash
 
+#installing k3s
+if ! command -v k3s &> /dev/null
+then
+    echo "------- K3S could not be found let's install it -------"
+    curl -sfL https://get.k3s.io | sh -
+    sudo chown -R vagrant /etc/rancher/k3s/
+    sudo helm --kubeconfig /etc/rancher/k3s/k3s.yaml list
+    ##getting pid of installation to wait until completed
+    PID_K3S_INSTALLATION=$!
+    export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+    #appending variable to bashrc if not exists (to prevent mutliple lines added after repeated provision executions)
+    grep -qxF 'export KUBECONFIG=/etc/rancher/k3s/k3s.yaml' ~/.bashrc || echo 'export KUBECONFIG=/etc/rancher/k3s/k3s.yaml' >> ~/.bashrc
+    ##must wait web interface of k3s is available to prevent errors on provisioning
+    wait $PID_K3S_INSTALLATION
+fi
+echo "Pods running:"
+k3s kubectl get pods --all-namespaces -o wide
+
 #sogno-demo DATABUS: install rabbitmq via helm
 # The `rabbitmq_values.yaml` file contains SOGNO specific overwrites of the default rabbitMQ values.
 cat > /etc/rancher/k3s/rabbitmq_values.yaml<< EOF

--- a/vagrant/simulationdemo.sh
+++ b/vagrant/simulationdemo.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+
+cd example-deployments/simulation-demo
+set -o nounset
+set -o errexit
+
+#SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+#pushd $SCRIPT_DIR && echo "Changed to $SCRIPT_DIR"
+
+#cleanup in case of halted vm wich is reprovisioning
+k3s kubectl delete deployments --all
+k3s kubectl delete services --all
+k3s kubectl delete pods --all --grace-period=0 --force
+k3s kubectl delete daemonset --all
+
+echo "Starting rabbitmq"
+k3s kubectl apply -f ./rabbitmq/deployment.yaml --kubeconfig /etc/rancher/k3s/k3s.yaml
+k3s kubectl apply -f ./rabbitmq/service.yaml --kubeconfig /etc/rancher/k3s/k3s.yaml
+
+REDISISRUNNING=`k3s kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml get pod redis-master-0 --output="jsonpath={.status.containerStatuses[*].ready}" | cut -d' ' -f2`
+echo "Redis already running? $REDISISRUNNING";
+if [ ! "$REDISISRUNNING" = true ] ;
+then
+    echo "installing redis" 
+    sudo helm install redis --set auth.enabled=false bitnami/redis --kubeconfig /etc/rancher/k3s/k3s.yaml
+    echo "installed redis"
+fi
+
+echo "Starting minio"  
+k3s kubectl apply -f ./minio/deployment.yaml --kubeconfig /etc/rancher/k3s/k3s.yaml
+k3s kubectl apply -f ./minio/service.yaml --kubeconfig /etc/rancher/k3s/k3s.yaml
+k3s kubectl apply -f ./minio/configmap.yaml --kubeconfig /etc/rancher/k3s/k3s.yaml
+
+#installing minikube
+#curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube_latest_amd64.deb
+#sudo dpkg -i minikube_latest_amd64.deb
+#minikube ssh docker pull amazon/aws-cli
+
+echo "Creating sogno-platform bucket"
+k3s kubectl run --kubeconfig /etc/rancher/k3s/k3s.yaml --rm -i --tty aws-cli --overrides='
+{
+  "apiVersion": "v1",
+  "kind": "Pod",
+  "metadata": {
+      "name": "aws-cli"
+  },
+  "spec": {
+    "containers": [
+      {
+        "name": "aws-cli",
+        "command": [ "/root/.aws/setup" ],
+        "spacer": [ "bash" ],
+        "image": "amazon/aws-cli",
+        "stdin": true,
+        "stdinOnce": true,
+        "tty": true,
+        "volumeMounts": [
+          {
+            "mountPath": "/root/.aws",
+            "name": "credentials-volume"
+          }
+        ]
+      }
+    ],
+    "volumes": [
+      {
+        "name": "credentials-volume",
+        "configMap":
+        {
+          "name": "aws-config",
+          "path": "/root/.aws",
+          "defaultMode": 511
+        }
+      }
+    ]
+  }
+}
+'  --image=amazon/aws-cli --restart=Never --
+
+
+echo "Starting file service" &&
+k3s kubectl apply -f ./file-service/deployment.yaml
+k3s kubectl apply -f ./file-service/configmap.yaml
+
+
+echo "Starting dpsim api" &&
+sudo helm install dpsim-api sogno/dpsim-api --kubeconfig /etc/rancher/k3s/k3s.yaml
+echo "Starting dpsim worker" && 
+sudo helm install dpsim-worker sogno/dpsim-worker --kubeconfig /etc/rancher/k3s/k3s.yaml
+
+echo "Pods running:"
+k3s kubectl get pods --all-namespaces -o wide

--- a/vagrant/simulationdemo.sh
+++ b/vagrant/simulationdemo.sh
@@ -122,7 +122,7 @@ sudo helm install dpsim-worker sogno/dpsim-worker
 
 #passing configuration to minikube kubectl commands
 mkdir -p /home/vagrant/.kube
-sudo kubectl config view --raw  >/home/vagrant/.kube/config
+sudo kubectl config view --raw  >> /home/vagrant/.kube/config
 
 echo "Pods running:"
 sudo kubectl get pods -o wide

--- a/vagrant/simulationdemo.sh
+++ b/vagrant/simulationdemo.sh
@@ -20,7 +20,7 @@ cd /home/vagrant/cri-dockerd
 mkdir -p bin
 go get && go build -o bin/cri-dockerd
 mkdir -p /usr/local/bin
-sudo install -o $USER -g $USER -m 0755 bin/cri-dockerd /usr/local/bin/cri-dockerd
+sudo install -o vagrant -g vagrant -m 0755 bin/cri-dockerd /usr/local/bin/cri-dockerd
 sudo cp -a packaging/systemd/* /etc/systemd/system
 sudo sed -i -e 's,/usr/bin/cri-dockerd,/usr/local/bin/cri-dockerd,' /etc/systemd/system/cri-docker.service
 sudo systemctl daemon-reload
@@ -119,5 +119,10 @@ sudo helm install dpsim-api sogno/dpsim-api
 echo "Starting dpsim worker" && 
 sudo helm install dpsim-worker sogno/dpsim-worker 
 
+
+#passing configuration to minikube kubectl commands
+mkdir -p /home/vagrant/.kube
+sudo kubectl config view --raw  >/home/vagrant/.kube/config
+
 echo "Pods running:"
-minikube kubectl get po -A
+sudo kubectl get pods -o wide

--- a/vagrant/vagrant-basic-bootstrap.sh
+++ b/vagrant/vagrant-basic-bootstrap.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+# Increase No of HPgs as required from sogno demo documentation
+echo 1024 | sudo tee /proc/sys/vm/nr_hugepages
+
+sudo ufw disable
+apt-get update
+apt-get install -y apt-transport-https ca-certificates curl gnupg2 software-properties-common net-tools
+
+
+#installing docker
+if ! command -v docker &> /dev/null
+then
+    echo "------- Docker could not be found let's install it -------"
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+    sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+    sudo apt-get install -y docker-ce 
+    # adding user vagrant to docker group
+    sudo usermod -aG docker $USER
+    sudo systemctl enable docker
+    sudo systemctl start  docker
+fi
+
+#installing kubernetes
+if ! command -v kubelet &> /dev/null
+then
+    echo "------- Kubernetes could not be found let's install it -------"
+    curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+    sudo bash -c 'echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list'
+    sudo apt-get update
+    sudo sudo apt-get install -y kubelet kubeadm kubectl
+    sudo systemctl enable kubelet
+    sudo systemctl start kubelet
+fi
+
+##installing helm
+if ! command -v helm &> /dev/null
+then
+    echo "------- Helm could not be found let's install it -------"
+    curl https://baltocdn.com/helm/signing.asc | gpg --dearmor | sudo tee /usr/share/keyrings/helm.gpg > /dev/null
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/helm.gpg] https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
+    sudo apt-get update
+    sudo apt-get install -y helm
+    sudo helm repo add bitnami https://charts.bitnami.com/bitnami
+    helm repo add sogno https://sogno-platform.github.io/helm-charts
+    helm repo add influxdata https://influxdata.github.io/helm-charts
+    helm repo add grafana https://grafana.github.io/helm-charts
+    helm repo update
+fi
+#
+
+##installing k3s
+if ! command -v k3s &> /dev/null
+then
+    echo "------- K3S could not be found let's install it -------"
+    curl -sfL https://get.k3s.io | sh -
+    sudo chown -R vagrant /etc/rancher/k3s/
+    sudo helm --kubeconfig /etc/rancher/k3s/k3s.yaml list
+    ##getting pid of installation to wait until completed
+    PID_K3S_INSTALLATION=$!
+    export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+    #appending variable to bashrc if not exists (to prevent mutliple lines added after repeated provision executions)
+    grep -qxF 'export KUBECONFIG=/etc/rancher/k3s/k3s.yaml' ~/.bashrc || echo 'export KUBECONFIG=/etc/rancher/k3s/k3s.yaml' >> ~/.bashrc
+    ##must wait web interface of k3s is available to prevent errors on provisioning
+    wait $PID_K3S_INSTALLATION
+fi
+
+echo "Pods running:"
+k3s kubectl get pods --all-namespaces -o wide
+
+echo "cluster info"
+k3s kubectl cluster-info
+
+if [ ! -d "example-deployments" ] 
+then
+  #checkout examples demo
+  git clone https://github.com/sogno-platform/example-deployments.git
+  rm -rf ./example-deployments/vagrant    
+fi

--- a/vagrant/vagrant-basic-bootstrap.sh
+++ b/vagrant/vagrant-basic-bootstrap.sh
@@ -28,7 +28,7 @@ then
     curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
     sudo bash -c 'echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list'
     sudo apt-get update
-    sudo sudo apt-get install -y kubelet kubeadm kubectl
+    sudo apt-get install -y kubelet kubeadm kubectl
     sudo systemctl enable kubelet
     sudo systemctl start kubelet
 fi
@@ -48,28 +48,6 @@ then
     helm repo update
 fi
 #
-
-##installing k3s
-if ! command -v k3s &> /dev/null
-then
-    echo "------- K3S could not be found let's install it -------"
-    curl -sfL https://get.k3s.io | sh -
-    sudo chown -R vagrant /etc/rancher/k3s/
-    sudo helm --kubeconfig /etc/rancher/k3s/k3s.yaml list
-    ##getting pid of installation to wait until completed
-    PID_K3S_INSTALLATION=$!
-    export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
-    #appending variable to bashrc if not exists (to prevent mutliple lines added after repeated provision executions)
-    grep -qxF 'export KUBECONFIG=/etc/rancher/k3s/k3s.yaml' ~/.bashrc || echo 'export KUBECONFIG=/etc/rancher/k3s/k3s.yaml' >> ~/.bashrc
-    ##must wait web interface of k3s is available to prevent errors on provisioning
-    wait $PID_K3S_INSTALLATION
-fi
-
-echo "Pods running:"
-k3s kubectl get pods --all-namespaces -o wide
-
-echo "cluster info"
-k3s kubectl cluster-info
 
 if [ ! -d "example-deployments" ] 
 then


### PR DESCRIPTION
Hi,
I'm Federico Paolantoni, a mate of the italian team working on the ADMS tender to adopt in production some components of SOGNO platform.
The ARETI team had some difficulties running examples because some provisioning steps require additional software setup.
I joined ARETI the in August 2022 the 1st and managed to get examples working using vagrant so i decided to support the team sharing the project an we tought to contribute at the main project.
Since ARETI isn't still providing a corporate github repository and  account I forked and committed the code with personal github account.
As I'm using my personal account I can't  sign my work  with corporate email (federico.paolantoni@areti.it)  according to  the Developer’s Certificate of Origin.
However ,feel free to reject the pull request o suggest a better approach to solve.